### PR TITLE
host/misc/udev: fix CC15 to cc15 in udev rule.

### DIFF
--- a/host/misc/udev/53-hackrf.rules.in
+++ b/host/misc/udev/53-hackrf.rules.in
@@ -3,6 +3,6 @@ ATTR{idVendor}=="1d50", ATTR{idProduct}=="604b", SYMLINK+="hackrf-jawbreaker-%k"
 # HackRF One
 ATTR{idVendor}=="1d50", ATTR{idProduct}=="6089", SYMLINK+="hackrf-one-%k", MODE="660", GROUP="@HACKRF_GROUP@"
 # HackRF One
-ATTR{idVendor}=="1d50", ATTR{idProduct}=="CC15", SYMLINK+="rad1o-%k", MODE="660", GROUP="@HACKRF_GROUP@"
+ATTR{idVendor}=="1d50", ATTR{idProduct}=="cc15", SYMLINK+="rad1o-%k", MODE="660", GROUP="@HACKRF_GROUP@"
 # HackRF DFU
 ATTR{idVendor}=="1fc9", ATTR{idProduct}=="000c", SYMLINK+="nxp-dfu-%k", MODE="660", GROUP="@HACKRF_GROUP@"


### PR DESCRIPTION
Capital letters don't work (tested on debian linux).
